### PR TITLE
Add converted amount endpoint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,8 +36,11 @@ dependencies {
     implementation("io.ktor:ktor-server-content-negotiation:$ktor_version")
     implementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
     implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
-
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
+    testImplementation("io.mockk:mockk:1.12.4")
 
     testImplementation("io.ktor:ktor-server-tests-jvm:$ktor_version")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
+    implementation("org.jetbrains.kotlin:kotlin-test:1.6.21")
+
 }

--- a/src/main/kotlin/com/exrate/ratessource/web/RoutingPlugin.kt
+++ b/src/main/kotlin/com/exrate/ratessource/web/RoutingPlugin.kt
@@ -17,7 +17,6 @@ fun Application.configureRouting() {
 
 
         get("/convertAmount") {
-            // TODO treat getting prams with corresponding 404
             val base = call.request.queryParameters["from"]!!
             val symbols = call.request.queryParameters["to"]!!
             val amount = call.request.queryParameters["amount"]

--- a/src/main/kotlin/com/exrate/ratessource/web/RoutingPlugin.kt
+++ b/src/main/kotlin/com/exrate/ratessource/web/RoutingPlugin.kt
@@ -1,5 +1,6 @@
 package com.exrate.ratessource.web
 
+import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -12,6 +13,28 @@ fun Application.configureRouting() {
             val query = getQueryFromUrl()
             val rates = ExchangeRateService.getRates(query).getOrThrow()
             call.respond(rates)
+        }
+
+
+        get("/convertAmount") {
+            // TODO treat getting prams with corresponding 404
+            val base = call.request.queryParameters["from"]!!
+            val symbols = call.request.queryParameters["to"]!!
+            val amount = call.request.queryParameters["amount"]
+
+
+            val result = ExchangeRateService.convert(GetRatesQuery(base, symbols.split(",")), amount!!.toDouble())
+
+            if (result.isSuccess) {
+                call.respond(result.getOrThrow())
+            } else {
+                val ex = result.exceptionOrNull()!!
+                val exClassName = ex.javaClass.name
+                call.respondText(
+                    "$exClassName: ${ex.message}",
+                    status = HttpStatusCode.ServiceUnavailable
+                )
+            }
         }
     }
 }

--- a/src/test/kotlin/com/exrate/ratessource/web/ExchangeRateServiceTestCase.kt
+++ b/src/test/kotlin/com/exrate/ratessource/web/ExchangeRateServiceTestCase.kt
@@ -23,7 +23,7 @@ internal class ExchangeRateServiceTestCase {
         val ratesQuery = GetRatesQuery("NZD", listOf("EUR"))
 
         coEvery { ExchangeRateService.queryExternal(ratesQuery) } returns Result.success(Rates(mapOf("USD" to 0.67.toBigDecimal())))
-//        coEvery { ExchangeRateService.cache.get(ratesQuery)} returns CompletableDeferred(Result.failure(Exception("THE CACHE BLEW UP!")))
+//        coEvery { ExchangeRateService.cache.get(ratesQuery)} returns CompletableDeferred(Result.success(Rates(mapOf("USD" to 0.67.toBigDecimal()))))
 
         val result = runBlocking {
             ExchangeRateService.convert(ratesQuery, 10000.0)

--- a/src/test/kotlin/com/exrate/ratessource/web/ExchangeRateServiceTestCase.kt
+++ b/src/test/kotlin/com/exrate/ratessource/web/ExchangeRateServiceTestCase.kt
@@ -1,0 +1,49 @@
+package com.exrate.ratessource.web
+
+import io.mockk.coEvery
+import io.mockk.mockkObject
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+
+
+internal class ExchangeRateServiceTestCase {
+
+//
+//    @AfterEach
+//    internal fun tearDown() {
+//        ExchangeRateService.cache.invalidateAll()
+//    }
+
+    @Test
+    internal fun goodCase() {
+        mockkObject(ExchangeRateService)
+
+        val ratesQuery = GetRatesQuery("NZD", listOf("EUR"))
+
+        coEvery { ExchangeRateService.queryExternal(ratesQuery) } returns Result.success(Rates(mapOf("USD" to 0.67.toBigDecimal())))
+//        coEvery { ExchangeRateService.cache.get(ratesQuery)} returns CompletableDeferred(Result.failure(Exception("THE CACHE BLEW UP!")))
+
+        val result = runBlocking {
+            ExchangeRateService.convert(ratesQuery, 10000.0)
+        }
+        assertEquals(true, result.isSuccess)
+        assertEquals(BigDecimal("6700.000"), (result as Result<Rates>).getOrNull()!!.rates["USD"])
+    }
+
+
+    @Test
+    internal fun badCase() {
+        mockkObject(ExchangeRateService)
+        val ratesQuery = GetRatesQuery("NZD", listOf("EUR"))
+
+        coEvery { ExchangeRateService.queryExternal(ratesQuery) } returns Result.failure(Exception("THE CACHE BLEW UP!"))
+
+        val result = runBlocking {
+            ExchangeRateService.convert(ratesQuery, 10000.0)
+        }
+        assertEquals(true, result.isFailure)
+        assertEquals("THE CACHE BLEW UP!", result.exceptionOrNull()!!.message)
+    }
+}


### PR DESCRIPTION
Context: In preparation of the Ebay-like bidding functionality we need to convert bid amounts based on the bidders currency.

This branch multiplies the final currency conversion values by the supplied query parameter value.
This piggybacks off the existing functionality but at the new /convertAmount endpoint.